### PR TITLE
chore: change the author name of the package

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@goproperly/browserslist-config-properly",
   "description": "Browserslist configuration for Properly websites",
   "license": "MIT",
-  "author": "Gavin Sharp <gavin@goproperly.com>",
+  "author": "Properly <info@properly.ca>",
   "homepage": "https://github.com/GoProperly/browserslist-config-properly#readme",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This commit changes the name of the author of the package to match what
we use in our Python packages.