### PR TITLE
Remove Gavin as default reviewer

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -5,5 +5,3 @@ update_configs:
   - package_manager: "javascript"
     directory: "/"
     update_schedule: "monthly"
-    default_reviewers:
-      - "gavinsharp"


### PR DESCRIPTION
Similar to https://github.com/GoProperly/js-proper-logger/pull/114 this
commit removes Gavin as a default reviewer. The effect of having him be
the default reviewer is that he would get tagged at the start of each
month.

This commit removes Gavin but does not add a new user or group.